### PR TITLE
flake: Add devShells

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{
+  lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "shoji";
+  name = "shoji";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "AdoPi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-5g0GaUfdndTfPMYQeNPR2mYlc6Y7YoGlVNBodmK3uiY=";
+  };
+
+  vendorHash = "sha256-uvpMGk0MbjR7kGRL2K1uP1vH30TAuz/ULEjObW6udyA=";
+
+  meta = with lib; {
+    description = "SSH Key Management Module";
+    homepage = "https://github.com/AdoPi/shoji";
+    license = licenses.gpl3;
+    maintainers = [ { name = "AdoPi"; email = "adopi.naj@gmail.com"; github = "AdoPi"; } ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711707400,
+        "narHash": "sha256-ggjKcR3OEmPnaYYB8f7PNXoe9f6NwtHpk/PZID42Hc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fb003bf6332198a6134312ae138182de9242a1e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1711707400,
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Manage SSH keys with Nix";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
+  outputs = {
+    self,
+    nixpkgs
+  }: let
+    systems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "aarch64-linux"
+    ];
+
+    forAllSystems = f: builtins.listToAttrs (map (system: { name = system; value = f system; }) systems);
+  in {
+    devShells = forAllSystems (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [ go ];
+        };
+      });
+  };
+}


### PR DESCRIPTION
Allows anyone to contribute easily without having to worry about installing go with `nix develop` in root project.

For the second commit https://github.com/AdoPi/shoji/pull/1/commits/e00a3201f2a404a4ede6b5ebae19d8f85272f5b1 
It can be usefull to use same env between package and devShells. 
After, use this repo as flake inputs for https://github.com/AdoPi/shoji-nix and remove package declaration here https://github.com/AdoPi/shoji-nix/blob/main/pkgs/shoji.nix

Example: https://github.com/mrdev023/shoji-nix/commit/d9f7ead6c74bb33b9d5b7787b334b77f18e749bc